### PR TITLE
FIX Illegal segment id when segment line endings are wrong

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-hl7-parser "3.4"
+(defproject clojure-hl7-parser "3.4.1"
   :description "A parser for parsing HL7 messages."
   :dependencies [[com.taoensso/timbre "1.6.0"]]
   :main com.nervestaple.hl7-parser.main)

--- a/src/com/nervestaple/hl7_parser/parser.clj
+++ b/src/com/nervestaple/hl7_parser/parser.clj
@@ -4,7 +4,8 @@
 (ns com.nervestaple.hl7-parser.parser
   (:use
    [taoensso.timbre :as timbre
-         :only (trace debug info warn error fatal spy)])
+         :only (trace debug info warn error fatal spy)]
+    [clojure.string :as string :only (trim)])
   (:import
    (java.text SimpleDateFormat)
    (java.util Date)
@@ -528,7 +529,7 @@ Reader."}
   (expect-char-int SEGMENT-DELIMITER (.read reader))
 
   ;; read in our segment id
-  (let [segment-id (read-text message reader)]
+  (let [segment-id (string/trim (read-text message reader))]
 
     ;; throw an exception if we don't get a valid segment id
     (if (or (nil? segment-id) (not= 3 (count segment-id)))


### PR DESCRIPTION
I only added a trim to get rid of spaces in a malformed hl7 message I got. Since I don't know the versioning scheme I added .1 to the version string, feel free to change it to suit your versioning scheme.