### PR TITLE
Drop Timbre dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject org.clojars.cmiles74/clojure-hl7-parser "3.4.5"
   :description "A parser for parsing HL7 messages."
   :url "https://github.com/cmiles74/clojure-hl7-messaging-2-parser"
-  :dependencies [[com.taoensso/timbre "5.1.2"]]
+  :dependencies [[org.clojure/clojure "1.10.0"]]
   :main com.nervestaple.hl7-parser.main
   :repositories [["clojars" {:url "https://repo.clojars.org" :cred :gpg}]])

--- a/src/com/nervestaple/hl7_parser/main.clj
+++ b/src/com/nervestaple/hl7_parser/main.clj
@@ -6,8 +6,6 @@
 (ns com.nervestaple.hl7-parser.main
   (:gen-class)
   (:require
-   [taoensso.timbre :as timbre
-    :refer (trace debug info warn error fatal spy)]
    [com.nervestaple.hl7-parser.parser :as parser]
    [com.nervestaple.hl7-parser.message :as message]
    [com.nervestaple.hl7-parser.batch :as batch]
@@ -24,18 +22,18 @@
         parsed-message (parser/parse message)]
 
     ;; provide a brief demonstration
-    (info (str "Message Id: "
-               (message/get-field-first-value parsed-message "MSH" 10)))
-    (info (str "MSH Segment: "
-               (pr-str (first (message/get-segments parsed-message "MSH")))))
-    (info (str "ACK: "
-               (message/ack-message {:sending-app "Clojure HL7 Parser"
-                                     :sending-facility "Test Facility"
-                                     :production-mode "P"
-                                     :version "2.3"
-                                     :text-message "Message processed successfully"}
-                                    "AA" parsed-message))
-          (info (str "Parsed: " (pr-str parsed-message))))
+    (println (str "Message Id: "
+                  (message/get-field-first-value parsed-message "MSH" 10)))
+    (println (str "MSH Segment: "
+                  (pr-str (first (message/get-segments parsed-message "MSH")))))
+    (println (str "ACK: "
+                  (message/ack-message {:sending-app "Clojure HL7 Parser"
+                                        :sending-facility "Test Facility"
+                                        :production-mode "P"
+                                        :version "2.3"
+                                        :text-message "Message processed successfully"}
+                                       "AA" parsed-message))
+          (println (str "Parsed: " (pr-str parsed-message))))
 
     ;; (with-open [reader (io/reader "file-of-batch-message.hl7.txt")]
     ;;   (let [messages (batch/read-messages reader)]

--- a/src/com/nervestaple/hl7_parser/parser.clj
+++ b/src/com/nervestaple/hl7_parser/parser.clj
@@ -3,8 +3,6 @@
 ;;
 (ns com.nervestaple.hl7-parser.parser
   (:use
-   [taoensso.timbre :as timbre
-         :only (trace debug info warn error fatal spy)]
     [clojure.string :as string :only (trim)])
   (:import
    (java.text SimpleDateFormat)


### PR DESCRIPTION
I used the same Clojure version (1.10.0) that Timbre pulled in before this change.

There appear to be no unit tests, but `lein run` yields the same output as before.