### PR TITLE
:sparkles: Accept Segment IDs Longer than Three Characters

### DIFF
--- a/src/com/nervestaple/hl7_parser/parser.clj
+++ b/src/com/nervestaple/hl7_parser/parser.clj
@@ -584,7 +584,7 @@
   (let [segment-id (string/trim (read-text message reader))]
 
     ;; throw an exception if we don't get a valid segment id
-    (when (or (nil? segment-id) (not= 3 (count segment-id)))
+    (when (or (nil? segment-id) (> 3 (count segment-id)))
       (throw (Exception. (str "Illegal segment id \"" segment-id "\" read"))))
 
     ;; create our new segment

--- a/test/com/nervestaple/hl7_parser/message_test.clj
+++ b/test/com/nervestaple/hl7_parser/message_test.clj
@@ -104,3 +104,15 @@
              {:id "MSA", :fields [{:content ["AR"]} nil {:content [""]}]}]}
            (sut/ack-message-fallback {:message-id "20230218125600"}
                                      "AR" "BLERG!")))))
+(deftest message-with-long-segment-id
+  (testing "Parses a message that includes a long segment identifier"
+    (is  (= {:id "ZQRY"
+             :fields [{:content ["Y"]} {:content ["Y"]} {:content []}
+                      {:content []} {:content []} {:content []} {:content []}
+                      {:content []} {:content []} {:content []} {:content []}
+                      {:content []} {:content []} {:content []}
+                      {:content ["20230915"]} {:content ["000072816"]}
+                      {:content ["1907838"]} {:content []} {:content []}
+                      {:content []} {:content []} {:content []} {:content []}
+                      {:content []} {:content []} {:content []}]}
+            (first (sut/get-segments (parser/parse (sample/message-long-segment-id)) "ZQRY"))))))

--- a/test/com/nervestaple/hl7_parser/sample_message.clj
+++ b/test/com/nervestaple/hl7_parser/sample_message.clj
@@ -31,3 +31,14 @@
        "PV1||O|OP^^||||4652^Paulson^Robert|||OP|||||||||9|||||||||||||||||||||||||20061019172717|20061019172718" (char parser/ASCII_CR)
        "ORC|NW|20061019172719" (char parser/ASCII_CR)
        "OBR|1|20061019172719||76770^Ultrasound: retroperitoneal^C4|||12349876" (char parser/ASCII_CR)))
+
+(defn message-long-segment-id
+  "Returns a short message that includes a proprietary segment with a long identifier"
+  []
+  (str "MSH|^~\\&|AcmeHIS|StJohn|CATH|StJohn|20061019172719||ORM^O01|"
+       (. (new Date) getTime) "|P|2.3" (char parser/ASCII_CR)
+       "PID|||20301||Durden^Tyler^^^Mr.||19700312|M|||88 Punchward Dr.^^Los Angeles^CA^11221^USA|||||||" (char parser/ASCII_CR)
+       "PV1||O|OP^^||||4652^Paulson^Robert|||OP|||||||||9|||||||||||||||||||||||||20061019172717|20061019172718" (char parser/ASCII_CR)
+       "ORC|NW|20061019172719" (char parser/ASCII_CR)
+       "OBR|1|20061019172719||76770^Ultrasound: retroperitoneal^C4|||12349876" (char parser/ASCII_CR)
+       "ZQRY|Y|Y|||||||||||||20230915|000072816|1907838|||||||||" (char parser/ASCII_CR)))


### PR DESCRIPTION
We have encountered proprietary vendor segments that have segment identifiers that are longer than three characters. This will alter the parser to accept these longer identifiers. Segment IDs that are less than three characters are treated as invalid. 